### PR TITLE
fix(subscriber): don't declare exchange if its the default

### DIFF
--- a/lib/subscribex/subscriber.ex
+++ b/lib/subscribex/subscriber.ex
@@ -130,7 +130,7 @@ defmodule Subscribex.Subscriber do
     Rabbit.declare_qos(channel, prefetch_count)
     Rabbit.declare_queue(channel, queue, config.queue_opts)
 
-    if exchange != "" do
+    unless exchange == "" do
       Rabbit.declare_exchange(channel, exchange, exchange_type, exchange_opts)
       Rabbit.bind_queue(channel, queue, exchange, binding_opts)
     end

--- a/lib/subscribex/subscriber.ex
+++ b/lib/subscribex/subscriber.ex
@@ -129,8 +129,11 @@ defmodule Subscribex.Subscriber do
 
     Rabbit.declare_qos(channel, prefetch_count)
     Rabbit.declare_queue(channel, queue, config.queue_opts)
-    Rabbit.declare_exchange(channel, exchange, exchange_type, exchange_opts)
-    Rabbit.bind_queue(channel, queue, exchange, binding_opts)
+
+    if exchange != "" do
+      Rabbit.declare_exchange(channel, exchange, exchange_type, exchange_opts)
+      Rabbit.bind_queue(channel, queue, exchange, binding_opts)
+    end
 
     {:ok, _consumer_tag} = AMQP.Basic.consume(channel, queue)
 


### PR DESCRIPTION
trying to re-declare the default exchange causes `subscribex` to crash with 

```
** (EXIT from #PID<0.357.0>) exited in: :gen_server.call(#PID<0.362.0>, {:call, {:"queue.bind", 0, "test_reply_queue", "", "", false, []}, :none, #PID<0.359.0>}, :infinity)
    ** (EXIT) shutdown: {:server_initiated_close, 403, "ACCESS_REFUSED - operation not permitted on the default exchange"}
```

because re-declaring (or binding queues) on the default exchange is illegal. 

Unless I'm just declaring it improperly, this should solve this issue.

For reference, here's a test config (using master)

```elixir
  def init do
    config = %Config{
      queue: "test",
      prefetch_count: 10,
      exchange: "",
      exchange_type: :direct,
      auto_ack: true,
      queue_opts: [durable: true]
    }

    {:ok, config}
  end
```