### PR TITLE
Npe/erlang 24 updates

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,7 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  locals_without_parens: [
+    prop_field: 3
+  ]
+]

--- a/lib/subscribex/batch_subscriber.ex
+++ b/lib/subscribex/batch_subscriber.ex
@@ -99,23 +99,23 @@ defmodule Subscribex.BatchSubscriber do
     @type queue_opts :: Keyword.t()
 
     @type t :: %__MODULE__{
-        batch_size: integer,
-        max_delay: integer,
-        binding_opts: binding_opts(),
-        dead_letter_exchange: String.t() | nil,
-        dead_letter_exchange_opts: Keyword.t(),
-        dead_letter_exchange_type: atom() | nil,
-        dead_letter_queue: String.t() | nil,
-        dead_letter_queue_opts: Keyword.t(),
-        dl_binding_opts: Keyword.t(),
-        exchange: String.t() | nil,
-        exchange_opts: exchange_opts(),
-        exchange_type: exchange_type(),
-        prefetch_count: integer,
-        queue: String.t() | nil,
-        queue_opts: queue_opts(),
-        broker: nil
-      }
+            batch_size: integer,
+            max_delay: integer,
+            binding_opts: binding_opts(),
+            dead_letter_exchange: String.t() | nil,
+            dead_letter_exchange_opts: Keyword.t(),
+            dead_letter_exchange_type: atom() | nil,
+            dead_letter_queue: String.t() | nil,
+            dead_letter_queue_opts: Keyword.t(),
+            dl_binding_opts: Keyword.t(),
+            exchange: String.t() | nil,
+            exchange_opts: exchange_opts(),
+            exchange_type: exchange_type(),
+            prefetch_count: integer,
+            queue: String.t() | nil,
+            queue_opts: queue_opts(),
+            broker: nil
+          }
 
     defstruct batch_size: nil,
               binding_opts: [],

--- a/lib/subscribex/broker.ex
+++ b/lib/subscribex/broker.ex
@@ -211,7 +211,7 @@ defmodule Subscribex.Broker do
     %{
       id: Module.concat(subscriber, Supervisor),
       type: :supervisor,
-      start: {Subscribex.Subscriber.Supervisor, [1, subscriber]}
+      start: {Subscribex.Subscriber.Supervisor, :start_link, [1, subscriber]}
     }
   end
 
@@ -219,7 +219,7 @@ defmodule Subscribex.Broker do
     %{
       id: Module.concat(subscriber, Supervisor),
       type: :supervisor,
-      start: {Subscribex.Subscriber.Supervisor, [count, subscriber]}
+      start: {Subscribex.Subscriber.Supervisor, :start_link, [count, subscriber]}
     }
   end
 

--- a/lib/subscribex/broker.ex
+++ b/lib/subscribex/broker.ex
@@ -133,8 +133,16 @@ defmodule Subscribex.Broker do
     connection_name = config(broker, :connection_name) || :"#{broker}.Connection"
 
     children = [
-      %{id: Subscribex.Connection, type: :worker, start: {Subscribex.Connection, :start_link, [rabbit_host(broker), connection_name]}},
-      %{id: Subscribex.Publisher, type: :supervisor, start: {Subscribex.Publisher, :start_link, [broker, count]}}
+      %{
+        id: Subscribex.Connection,
+        type: :worker,
+        start: {Subscribex.Connection, :start_link, [rabbit_host(broker), connection_name]}
+      },
+      %{
+        id: Subscribex.Publisher,
+        type: :supervisor,
+        start: {Subscribex.Publisher, :start_link, [broker, count]}
+      }
     ]
 
     opts = [strategy: :one_for_all, name: :"#{broker}.Supervisor"]

--- a/lib/subscribex/broker.ex
+++ b/lib/subscribex/broker.ex
@@ -50,7 +50,6 @@ defmodule Subscribex.Broker do
   """
 
   require Logger
-  import Supervisor.Spec
 
   @type channel :: %AMQP.Channel{}
 
@@ -134,8 +133,8 @@ defmodule Subscribex.Broker do
     connection_name = config(broker, :connection_name) || :"#{broker}.Connection"
 
     children = [
-      worker(Subscribex.Connection, [rabbit_host(broker), connection_name]),
-      supervisor(Subscribex.Publisher, [broker, count])
+      %{id: Subscribex.Connection, type: :worker, start: {Subscribex.Connection, :start_link, [rabbit_host(broker), connection_name]}},
+      %{id: Subscribex.Publisher, type: :supervisor, start: {Subscribex.Publisher, :start_link, [broker, count]}}
     ]
 
     opts = [strategy: :one_for_all, name: :"#{broker}.Supervisor"]
@@ -201,19 +200,19 @@ defmodule Subscribex.Broker do
 
   @doc false
   def subscriber_spec(subscriber) when is_atom(subscriber) do
-    supervisor(
-      Subscribex.Subscriber.Supervisor,
-      [1, subscriber],
-      id: Module.concat(subscriber, Supervisor)
-    )
+    %{
+      id: Module.concat(subscriber, Supervisor),
+      type: :supervisor,
+      start: {Subscribex.Subscriber.Supervisor, [1, subscriber]}
+    }
   end
 
   def subscriber_spec({count, subscriber}) do
-    supervisor(
-      Subscribex.Subscriber.Supervisor,
-      [count, subscriber],
-      id: Module.concat(subscriber, Supervisor)
-    )
+    %{
+      id: Module.concat(subscriber, Supervisor),
+      type: :supervisor,
+      start: {Subscribex.Subscriber.Supervisor, [count, subscriber]}
+    }
   end
 
   @doc false

--- a/lib/subscribex/publisher/pool.ex
+++ b/lib/subscribex/publisher/pool.ex
@@ -23,7 +23,7 @@ defmodule Subscribex.Publisher.Pool do
     result =
       broker
       |> group_name
-      |> :pg.get_members()
+      |> :pg.get_local_members()
       |> Enum.random()
 
     case result do

--- a/lib/subscribex/publisher/pool.ex
+++ b/lib/subscribex/publisher/pool.ex
@@ -23,7 +23,8 @@ defmodule Subscribex.Publisher.Pool do
     result =
       broker
       |> group_name
-      |> :pg2.get_closest_pid()
+      |> :pg.get_members()
+      |> Enum.random()
 
     case result do
       pid when is_pid(pid) -> {:ok, %AMQP.Channel{pid: pid}}
@@ -35,29 +36,39 @@ defmodule Subscribex.Publisher.Pool do
   def add(broker, pid) do
     broker
     |> group_name
-    |> :pg2.join(pid)
+    |> :pg.join(pid)
   end
 
   # Callback Functions
 
   def init({broker, count, connection_name}) do
-    broker
-    |> group_name
-    |> :pg2.create()
-
     children =
-      for n <- 1..count do
-        worker(
-          Subscribex.Publisher.Pool.Worker,
-          [broker, connection_name],
-          id: :"#{__MODULE__}.Worker.#{n}"
-        )
-      end
+      start_pg() ++
+        for n <- 1..count do
+          %{
+            id: :"#{__MODULE__}.Worker.#{n}",
+            type: :worker,
+            start: {Subscribex.Publisher.Pool.Worker, :start_link, [broker, connection_name]}
+          }
+        end
 
-    supervise(children, strategy: :one_for_one)
+    Supervisor.init(children, strategy: :one_for_one)
   end
 
   # Private Functions
+
+  defp start_pg do
+    if is_nil(Process.whereis(:pg)) do
+      [
+        %{
+          id: :pg,
+          start: {:pg, :start_link, []}
+        }
+      ]
+    else
+      []
+    end
+  end
 
   defp group_name(broker) do
     {broker, :publisher_pool}

--- a/lib/subscribex/subscriber.ex
+++ b/lib/subscribex/subscriber.ex
@@ -84,22 +84,22 @@ defmodule Subscribex.Subscriber do
     @type queue_opts :: Keyword.t()
 
     @type t :: %__MODULE__{
-        auto_ack: boolean | nil,
-        binding_opts: binding_opts(),
-        dead_letter_exchange: String.t() | nil,
-        dead_letter_exchange_opts: Keyword.t(),
-        dead_letter_exchange_type: atom() | nil,
-        dead_letter_queue: String.t() | nil,
-        dead_letter_queue_opts: Keyword.t(),
-        dl_binding_opts: Keyword.t(),
-        exchange: String.t() | nil,
-        exchange_opts: exchange_opts(),
-        exchange_type: exchange_type(),
-        prefetch_count: integer,
-        queue: String.t() | nil,
-        queue_opts: queue_opts(),
-        broker: nil
-      }
+            auto_ack: boolean | nil,
+            binding_opts: binding_opts(),
+            dead_letter_exchange: String.t() | nil,
+            dead_letter_exchange_opts: Keyword.t(),
+            dead_letter_exchange_type: atom() | nil,
+            dead_letter_queue: String.t() | nil,
+            dead_letter_queue_opts: Keyword.t(),
+            dl_binding_opts: Keyword.t(),
+            exchange: String.t() | nil,
+            exchange_opts: exchange_opts(),
+            exchange_type: exchange_type(),
+            prefetch_count: integer,
+            queue: String.t() | nil,
+            queue_opts: queue_opts(),
+            broker: nil
+          }
 
     defstruct auto_ack: nil,
               binding_opts: [],

--- a/lib/subscribex/subscriber/supervisor.ex
+++ b/lib/subscribex/subscriber/supervisor.ex
@@ -1,8 +1,6 @@
 defmodule Subscribex.Subscriber.Supervisor do
   @moduledoc false
 
-  use Supervisor
-
   def start_link(child) when is_atom(child), do: start_link({child, default_worker_count()})
   def start_link({child, count}) when is_atom(child), do: start_link({child, count}, {})
 
@@ -16,14 +14,12 @@ defmodule Subscribex.Subscriber.Supervisor do
     do: init({child, String.to_integer(count), args})
 
   def init({child, count, args}) when is_integer(count) do
-    import Supervisor.Spec
-
     children =
       Enum.map(0..(count - 1), fn n ->
-        worker(child, args, id: :"#{child}_#{n}")
+        %{id: :"#{child}_#{n}", type: :worker, start: {child, args}}
       end)
 
-    supervise(
+    Supervisor.init(
       children,
       strategy: :one_for_one,
       name: :"#{child}.Supervisor"

--- a/lib/subscribex/subscriber/supervisor.ex
+++ b/lib/subscribex/subscriber/supervisor.ex
@@ -16,7 +16,7 @@ defmodule Subscribex.Subscriber.Supervisor do
   def init({child, count, args}) when is_integer(count) do
     children =
       Enum.map(0..(count - 1), fn n ->
-        %{id: :"#{child}_#{n}", type: :worker, start: {child, args}}
+        %{id: :"#{child}_#{n}", type: :worker, start: {child, :start_link, args}}
       end)
 
     Supervisor.init(

--- a/mix.exs
+++ b/mix.exs
@@ -1,13 +1,13 @@
 defmodule Subscribex.Mixfile do
   use Mix.Project
 
-  @version "0.10.0-rc.1"
+  @version "0.11.0-rc.1"
 
   def project do
     [
       app: :subscribex,
       version: @version,
-      elixir: "~> 1.3",
+      elixir: "~> 1.12",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       package: package(),
@@ -35,15 +35,15 @@ defmodule Subscribex.Mixfile do
 
   def application do
     [
-      applications: [:logger]
+      extra_applications: [:logger]
     ]
   end
 
   defp deps do
     [
-      {:amqp, "~> 0.3.0"},
-      {:ex_doc, "~> 0.19", only: :dev},
-      {:dialyxir, "0.3.5", only: :dev}
+      {:amqp, "~> 3.0"},
+      {:ex_doc, "~> 0.25.3", only: :dev},
+      {:dialyxir, "~> 1.1", only: :dev, runtime: false}
     ]
   end
 
@@ -75,7 +75,7 @@ defmodule Subscribex.Mixfile do
           Subscribex.Subscriber.Config,
           Subscribex.BatchSubscriber,
           Subscribex.BatchSubscriber.Config
-        ],
+        ]
       ]
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,11 +1,75 @@
 %{
-  "amqp": {:hex, :amqp, "0.3.0", "45c26acbc63507e4bf7fe9b2e7e32733dcf478a1695439baedc4690722b652d1", [:mix], [{:amqp_client, "~> 3.6.8", [hex: :amqp_client, repo: "hexpm", optional: false]}, {:rabbit_common, "~> 3.6.8", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm"},
-  "amqp_client": {:hex, :amqp_client, "3.6.12", "dfdfe7be661feb96ece404092a47431a73797ad412959732d940f96f80290da0", [:make, :rebar3], [{:rabbit_common, "3.6.12", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm"},
-  "dialyxir": {:hex, :dialyxir, "0.3.5", "eaba092549e044c76f83165978979f60110dc58dd5b92fd952bf2312f64e9b14", [:mix], []},
-  "earmark": {:hex, :earmark, "1.3.0", "17f0c38eaafb4800f746b457313af4b2442a8c2405b49c645768680f900be603", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "0.5.6", "da47b331b1fe0a5f0380cc3a6967200eac5e1daaa9c6bff4b0310b3fcc12b98f", [:mix], [{:nimble_parsec, "~> 0.4.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
-  "rabbit_common": {:hex, :rabbit_common, "3.6.12", "28dfb9ce4decf64caa9d9e70977ab57af983bc2795fd9db349bfc254a8b45235", [:make, :rebar3], [], "hexpm"},
+  amqp:
+    {:hex, :amqp, "3.0.0", "66e8e17561f19ba85bff7df4f77560e8de8ddd53958c5c15ccb2583bb937564f",
+     [:mix], [{:amqp_client, "~> 3.9.1", [hex: :amqp_client, repo: "hexpm", optional: false]}],
+     "hexpm", "2b0b27223196a511d5dd5a7291ba48366ccb405a0b5ea1b966bf9f80fd17f1b1"},
+  amqp_client:
+    {:hex, :amqp_client, "3.9.5",
+     "be7b022550f1c0ddfb23a3145fc3d59b5edb9fdfcc1dd705796c97f77e9eac98", [:make, :rebar3],
+     [{:rabbit_common, "3.9.5", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm",
+     "dc7cd4d35b4aff28620f7cd58a9b8f394dad93cf896704b1f770554f5ff20fde"},
+  credentials_obfuscation:
+    {:hex, :credentials_obfuscation, "2.4.0",
+     "9fb57683b84899ca3546b384e59ab5d3054a9f334eba50d74c82cd0ae82dd6ca", [:rebar3], [], "hexpm",
+     "d28a89830e30698b075de9a4dbe683a20685c6bed1e3b7df744a0c06e6ff200a"},
+  dialyxir:
+    {:hex, :dialyxir, "1.1.0", "c5aab0d6e71e5522e77beff7ba9e08f8e02bad90dfbeffae60eaf0cb47e29488",
+     [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm",
+     "07ea8e49c45f15264ebe6d5b93799d4dd56a44036cf42d0ad9c960bc266c0b9a"},
+  earmark:
+    {:hex, :earmark, "1.3.0", "17f0c38eaafb4800f746b457313af4b2442a8c2405b49c645768680f900be603",
+     [:mix], [], "hexpm", "f8b8820099caf0d5e72ae6482d2b0da96f213cbbe2b5b2191a37966e119eaa27"},
+  earmark_parser:
+    {:hex, :earmark_parser, "1.4.15",
+     "b29e8e729f4aa4a00436580dcc2c9c5c51890613457c193cc8525c388ccb2f06", [:mix], [], "hexpm",
+     "044523d6438ea19c1b8ec877ec221b008661d3c27e3b848f4c879f500421ca5c"},
+  erlex:
+    {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e",
+     [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
+  ex_doc:
+    {:hex, :ex_doc, "0.25.3", "3edf6a0d70a39d2eafde030b8895501b1c93692effcbd21347296c18e47618ce",
+     [:mix],
+     [
+       {:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]},
+       {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]},
+       {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}
+     ], "hexpm", "9ebebc2169ec732a38e9e779fd0418c9189b3ca93f4a676c961be6c1527913f5"},
+  jsx:
+    {:hex, :jsx, "3.1.0", "d12516baa0bb23a59bb35dccaf02a1bd08243fcbb9efe24f2d9d056ccff71268",
+     [:rebar3], [], "hexpm", "0c5cc8fdc11b53cc25cf65ac6705ad39e54ecc56d1c22e4adb8f5a53fb9427f3"},
+  makeup:
+    {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c",
+     [:mix],
+     [
+       {:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}
+     ], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
+  makeup_elixir:
+    {:hex, :makeup_elixir, "0.15.1",
+     "b5888c880d17d1cc3e598f05cdb5b5a91b7b17ac4eaf5f297cb697663a1094dd", [:mix],
+     [
+       {:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]},
+       {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}
+     ], "hexpm", "db68c173234b07ab2a07f645a5acdc117b9f99d69ebf521821d89690ae6c6ec8"},
+  makeup_erlang:
+    {:hex, :makeup_erlang, "0.1.1",
+     "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix],
+     [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm",
+     "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
+  nimble_parsec:
+    {:hex, :nimble_parsec, "1.1.0",
+     "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm",
+     "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
+  rabbit_common:
+    {:hex, :rabbit_common, "3.9.5",
+     "4f94e901782db08d2e944bea8d8537010f724d1e37d7948661e48b887728c2a3", [:make, :rebar3],
+     [
+       {:credentials_obfuscation, "2.4.0",
+        [hex: :credentials_obfuscation, repo: "hexpm", optional: false]},
+       {:jsx, "3.1.0", [hex: :jsx, repo: "hexpm", optional: false]},
+       {:recon, "2.5.1", [hex: :recon, repo: "hexpm", optional: false]}
+     ], "hexpm", "d4f238df7c2dc67ececcd1e8a70eafcc15fdb69db1e82820533dbe92a229655a"},
+  recon:
+    {:hex, :recon, "2.5.1", "430ffa60685ac1efdfb1fe4c97b8767c92d0d92e6e7c3e8621559ba77598678a",
+     [:mix, :rebar3], [], "hexpm",
+     "5721c6b6d50122d8f68cccac712caa1231f97894bab779eff5ff0f886cb44648"}
 }


### PR DESCRIPTION
Updating to Erlang 24.1, Elixir 1.12.3

https://hexdocs.pm/elixir/master/Supervisor.Spec.html
![image](https://user-images.githubusercontent.com/16036034/136288251-79df4fc9-adda-42e8-afdc-d220d787dbfa.png)

Supervisor is now module based, meaning a process can declare its own specifications on how it should be supervised.
Supervisor.Spec is deprecated in favor of this strategy.

http://erlang.org/documentation/doc-11.0-rc3/lib/kernel-7.0/doc/html/pg2.html
![image](https://user-images.githubusercontent.com/16036034/136288185-49d0b218-a915-4401-aaf7-564037cd0870.png)

Erlang 24 removed `pg2` in favor of using `pg` for process groups.

This MR is to update those two areas, as well as update the `application.ex` to the new format to start dependancies and add a formatter file.